### PR TITLE
Bugfixes

### DIFF
--- a/fender.bnf
+++ b/fender.bnf
@@ -1,4 +1,4 @@
-delimitedList<elem, delim, whitespace> ::= elem whitespace? (delim whitespace? elem)*
+delimitedList<elem, delim, whitespace> ::= elem (whitespace? delim whitespace? elem)*
 wrappedDelimitedList<begin, end, elem, delim, whitespace> ::= begin whitespace? delimitedList<elem, delim, whitespace>? whitespace? end
 
 sep ::= [ \t]+

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -405,12 +405,12 @@ fn parse_expr(
     writer: &mut VMWriter<FenderTypeSystem>,
     scope: &mut LexicalScope,
 ) -> Result<Expression<FenderTypeSystem>, Box<dyn Error>> {
-    let token = &token.children[0];
     Ok(match token.get_name().as_deref().unwrap() {
         "add" | "mul" | "pow" | "range" | "cmp" | "or" | "and" => {
             parse_binary_operation(token, writer, scope)?
         }
         "term" => parse_term(token, writer, scope)?,
+        "expr" => parse_expr(&token.children[0], writer, scope)?,
         _ => unreachable!(),
     })
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -46,7 +46,7 @@ impl<'a> LexicalScope<'a> {
         captures.push(parent_var);
         self.variables
             .borrow_mut()
-            .insert(name.to_string(), VariableType::Captured(captures.len()));
+            .insert(name.to_string(), VariableType::Captured(captures.len() - 1));
         Ok(())
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -285,7 +285,7 @@ fn parse_value(
 ) -> Result<Expression<FenderTypeSystem>, Box<dyn Error>> {
     Ok(match token.children[0].get_name().as_deref().unwrap() {
         "literal" => parse_literal(&token.children[0], writer, scope)?,
-        "lambdaParamer" => Expression::stack(0),
+        "lambdaParameter" => Expression::stack(0),
         "enclosedExpr" => parse_expr(&token.children[0], writer, scope)?,
         "name" => {
             if let Some(addr) = scope.globals.get(&token.get_match()) {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -410,7 +410,7 @@ fn parse_expr(
             parse_binary_operation(token, writer, scope)?
         }
         "term" => parse_term(token, writer, scope)?,
-        "expr" => parse_expr(&token.children[0], writer, scope)?,
+        "expr" | "enclosedExpr" => parse_expr(&token.children[0], writer, scope)?,
         _ => unreachable!(),
     })
 }


### PR DESCRIPTION
Fixes: Crashing on programs with multiple lines

What was happening: An expression would consume the newline following it, preventing the newline from being parsed to indicate the start of the next statement

Fixes: Crashing on binary operations

What was happening: `parse_expr` was unwrapping the token it was passed into its child, but the token it was passed was not always an `expr` token, it could be an `add` or `term` token for example

Fixes: Crashing on encountering the lambda parameter (`$`)

What was happening: There was a typo in a match statement, matching the wrong name

Fixes: Variable assignment having no effect

What was happening: Freight was calling `clone()` on all variable values, causing their references to not get correctly updated when AssignDynamic was used

Fixes: Global variables always being declared as null

What was happening: parse_statement was always treating declaration as happening on the stack, but in the main function it should be using globals

Fixes: Attempting to use a captured value crashes

What was happening: The index of the captured value was incorrectly being set to 1 higher than it should have been because I took the length of the captured variables list after adding to it instead of before