### PR TITLE
Fix function argument parsing

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5,6 +5,7 @@ use fender::{
     operators::FenderBinaryOperator, operators::FenderUnaryOperator, FenderTypeSystem, FenderValue,
 };
 use flux_bnf::lexer::{CullStrategy, Lexer};
+use flux_bnf::tokens::iterators::ignore_iter::IgnoreTokensIteratorExt;
 use flux_bnf::tokens::Token;
 use freight_vm::execution_engine::ExecutionEngine;
 use freight_vm::expression::{Expression, NativeFunction, VariableType};
@@ -137,9 +138,8 @@ fn parse_main_function(token: &Token) -> Result<ExecutionEngine<FenderTypeSystem
 
 fn code_body_uses_lambda_parameter(token: &Token) -> bool {
     token
-        .recursive_children()
-        .ignore("codeBody")
-        .filter(|t| t.get_name().as_deref() == Some("lambdaParameter"))
+        .recursive_children_named("lambdaParameter")
+        .ignore_token("codeBody")
         .next()
         .is_some()
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -145,7 +145,7 @@ fn parse_args(token: &Token) -> Vec<String> {
         if arg.children.len() == 2 {
             unimplemented!();
         }
-        let name = arg.children[0].get_name().clone().unwrap();
+        let name = arg.children[0].get_match();
         arg_names.push(name);
     }
     arg_names
@@ -214,7 +214,7 @@ fn parse_statement(
         "assignment" => {
             let target = &token.children[0];
             let value = &token.children[token.children.len() - 1];
-            if token.direct_children_named("assignOp").count() > 0 {
+            if token.children_named("assignOp").count() > 0 {
                 unimplemented!()
             }
             let target = parse_expr(target, writer, scope)?;
@@ -311,7 +311,7 @@ fn parse_invoke_args(
     let token = &token.children[0];
     match token.get_name().as_deref().unwrap() {
         "invokeArgs" => token
-            .direct_children_named("expr")
+            .children_named("expr")
             .map(|arg| parse_expr(arg, writer, scope))
             .collect(),
         "codeBody" => todo!(),
@@ -351,7 +351,7 @@ fn parse_term(
     writer: &mut VMWriter<FenderTypeSystem>,
     scope: &mut LexicalScope,
 ) -> Result<Expression<FenderTypeSystem>, Box<dyn Error>> {
-    let value = token.direct_children_named("value").next().unwrap();
+    let value = token.children_named("value").next().unwrap();
     let mut value = parse_value(value, writer, scope)?;
     if let Some("tailOperationChain") = token.children[token.children.len() - 1]
         .get_name()

--- a/test.fndr
+++ b/test.fndr
@@ -1,1 +1,6 @@
-1 + 1 + 1
+{
+   "Hello, world!".print();
+   {
+      $.print()
+   }("Hi 2")
+}()


### PR DESCRIPTION
Fixes: Function arguments cannot be referenced

What was wrong: The token names were being parsed instead of their matches, so every argument was just being called `name`