### PR TITLE
Fix pass by reference/value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 [[package]]
 name = "flux_bnf"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Flux?branch=master#1b2f64687058c677f342056e8bf5cae5a0684c31"
+source = "git+https://github.com/FenderLang/Flux?branch=master#1219add66d89b4a97f38fe640a81d9eb9dd72b14"
 
 [[package]]
 name = "freight_vm"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Freight?branch=master#b671aa2701897506f207f9521b511b8d7d0c80ed"
+source = "git+https://github.com/FenderLang/Freight?rev=0ba62c90e20c09ffb5941316bb5cd32c53c0dc67#0ba62c90e20c09ffb5941316bb5cd32c53c0dc67"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-freight_vm = {git = "https://github.com/FenderLang/Freight", branch = "master"}
+freight_vm = {git = "https://github.com/FenderLang/Freight", rev="0ba62c90e20c09ffb5941316bb5cd32c53c0dc67"}
 flux_bnf = {git = "https://github.com/FenderLang/Flux", branch = "master"}

--- a/src/fender_reference.rs
+++ b/src/fender_reference.rs
@@ -43,7 +43,7 @@ pub enum FenderReference {
 
 impl FenderReference {
     pub fn get_pass_object(&self) -> FenderReference {
-        if self.get_type_id().is_primitive() {
+        if self.get_type_id().is_value_type() {
             self.deep_clone()
         } else {
             self.dupe_ref()

--- a/src/fender_reference.rs
+++ b/src/fender_reference.rs
@@ -7,14 +7,8 @@ use std::{
     rc::Rc,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InternalReference(Rc<UnsafeCell<FenderValue>>);
-
-impl Clone for InternalReference {
-    fn clone(&self) -> Self {
-        InternalReference::new((**self).clone())
-    }
-}
 
 impl InternalReference {
     pub fn new(value: FenderValue) -> Self {
@@ -42,7 +36,6 @@ impl PartialEq for InternalReference {
     }
 }
 
-#[derive(Clone)]
 pub enum FenderReference {
     FRef(InternalReference),
     FRaw(FenderValue),
@@ -53,19 +46,7 @@ impl FenderReference {
         if self.get_type_id().is_primitive() {
             self.deep_clone()
         } else {
-            self.dupe_reference()
-        }
-    }
-
-    pub fn deep_clone(&self) -> FenderReference {
-        // depending on how we use this it should be a `FRaw` instead of `FRef`
-        FenderReference::FRef(InternalReference::new(self.deref().deep_clone()))
-    }
-
-    pub fn dupe_reference(&self) -> FenderReference {
-        match self {
-            FenderReference::FRef(_) => self.clone(),
-            FenderReference::FRaw(_) => unreachable!(),
+            self.dupe_ref()
         }
     }
 }
@@ -126,6 +107,12 @@ impl Debug for FenderReference {
     }
 }
 
+impl Clone for FenderReference {
+    fn clone(&self) -> Self {
+        self.get_pass_object()
+    }
+}
+
 impl Value for FenderReference {
     type TS = FenderTypeSystem;
 
@@ -146,15 +133,18 @@ impl Value for FenderReference {
     }
 
     fn deep_clone(&self) -> Self {
-        todo!()
+        match self {
+            FenderReference::FRaw(v) => FenderReference::FRaw(v.deep_clone()),
+            FenderReference::FRef(r) => {
+                FenderReference::FRef(InternalReference::new(r.deep_clone()))
+            }
+        }
     }
 
     fn dupe_ref(&self) -> Self {
         match self {
-            FenderReference::FRef(internal_ref) => {
-                FenderReference::FRef(InternalReference(internal_ref.0.clone()))
-            }
-            FenderReference::FRaw(_) => self.clone(),
+            FenderReference::FRef(internal_ref) => FenderReference::FRef(internal_ref.clone()),
+            FenderReference::FRaw(_) => self.deep_clone(),
         }
     }
 
@@ -171,6 +161,13 @@ impl Value for FenderReference {
 
     fn assign(&mut self, value: FenderReference) {
         *self.deref_mut() = (*value).clone();
+    }
+
+    fn into_ref(self) -> Self {
+        match self {
+            FenderReference::FRef(_) => self,
+            FenderReference::FRaw(v) => FenderReference::FRef(InternalReference::new(v)),
+        }
     }
 }
 

--- a/src/fender_value.rs
+++ b/src/fender_value.rs
@@ -1,4 +1,4 @@
-use freight_vm::function::FunctionRef;
+use freight_vm::{function::FunctionRef, value::Value};
 
 use crate::{fender_reference::InternalReference, FenderReference, FenderTypeId, FenderTypeSystem};
 
@@ -41,7 +41,19 @@ impl FenderValue {
     }
 
     pub fn deep_clone(&self) -> FenderValue {
-        todo!()
+        use FenderValue::*;
+        match self {
+            Ref(v) => Ref(InternalReference::new(v.deep_clone())),
+            Int(i) => Int(*i),
+            Float(f) => Float(*f),
+            Char(c) => Char(*c),
+            String(s) => String(s.clone()),
+            Bool(b) => Bool(*b),
+            Error(e) => Error(e.clone()),
+            Function(f) => Function(f.clone()),
+            List(l) => List(l.iter().map(Value::deep_clone).collect()),
+            Null => Null,
+        }
     }
 
     pub fn len(&self) -> Result<usize, String> {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -79,3 +79,8 @@ fn test_lists() {
         ])
     );
 }
+
+#[test]
+fn pass_by_reference_test() {
+    assert_eq!(*run(include_str!("passByRef.fndr")), FenderValue::Int(8));
+}

--- a/src/test/passByRef.fndr
+++ b/src/test/passByRef.fndr
@@ -1,0 +1,39 @@
+$while = (cond, func) {
+    if(cond(), {func(); while(cond, func)}, {})
+}
+
+$then = (bool, func) {
+    if(bool, {[bool, func()]}, {[false]})
+}
+
+$else = (thenResult, func) {
+    if(thenResult[0], {thenResult[1]}, func)
+}
+
+$each = (list, func) {
+    $i = 0
+    while({i < list.len()}, {
+        func(list[i])
+        i = i + 1
+    })
+}
+
+$map = (list, func) {
+    $i = 0
+    while({i < list.len()}, {
+        list[i] = func(list[i])
+        i = i + 1
+    })
+    list
+}
+
+$fold = (list, accum, func) {
+    $i = 0
+    while({i < list.len()}, {
+        accum = func(accum, list[i])
+        i = i + 1
+    })
+    accum
+}
+
+["1", "4", "3"].map(int).fold(0, (a, b) {a + b})

--- a/src/type_sys/type_id.rs
+++ b/src/type_sys/type_id.rs
@@ -13,7 +13,7 @@ pub enum FenderTypeId {
 }
 
 impl FenderTypeId {
-    pub fn is_primitive(&self) -> bool {
+    pub fn is_value_type(&self) -> bool {
         use FenderTypeId::*;
         match self {
             Int => true,
@@ -23,7 +23,7 @@ impl FenderTypeId {
             Null => true,
             Reference => false,
             Function => true,
-            String => true,
+            String => false,
             List => false,
             Char => true,
         }


### PR DESCRIPTION
Primitives are now passed by value, non-primitives are passed by reference, and FRaw will always be converted to FRef when passed as function arguments