### PR TITLE
Fix pass by reference

### DIFF
--- a/src/fender_reference.rs
+++ b/src/fender_reference.rs
@@ -10,46 +10,52 @@ use std::{
     rc::Rc,
 };
 
-#[derive(Clone, Debug)]
-pub struct InternalReference(Rc<UnsafeCell<FenderValue>>);
+#[derive(Clone)]
+pub struct InternalReference<T>(Rc<UnsafeCell<T>>);
 
-impl InternalReference {
-    pub fn new(value: FenderValue) -> Self {
+impl<T: Debug> Debug for InternalReference<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "InternalReference({:?})", **self)
+    }
+}
+
+impl<T> InternalReference<T> {
+    pub fn new(value: T) -> Self {
         Self(Rc::new(UnsafeCell::new(value)))
     }
 }
 
-impl Deref for InternalReference {
-    type Target = FenderValue;
+impl<T> Deref for InternalReference<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.0.get() }
     }
 }
 
-impl DerefMut for InternalReference {
+impl<T> DerefMut for InternalReference<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { self.0.get().as_mut().unwrap() }
     }
 }
 
-impl PartialEq for InternalReference {
+impl<T: PartialEq> PartialEq for InternalReference<T> {
     fn eq(&self, other: &Self) -> bool {
         **self == **other
     }
 }
 
+#[derive(Debug)]
 pub enum FenderReference {
-    FRef(InternalReference),
+    FRef(InternalReference<FenderValue>),
     FRaw(FenderValue),
 }
 
 impl FenderReference {
     pub fn get_pass_object(&self) -> FenderReference {
-        if self.get_type_id().is_value_type() {
-            self.deep_clone()
-        } else {
-            self.dupe_ref()
+        match self {
+            FenderReference::FRef(r) => FenderReference::FRef(r.deref().clone().into()),
+            FenderReference::FRaw(v) => FenderReference::FRaw(v.clone()),
         }
     }
 }
@@ -92,6 +98,12 @@ impl From<FenderValue> for FenderReference {
     }
 }
 
+impl<T> From<T> for InternalReference<T> {
+    fn from(value: T) -> Self {
+        InternalReference::new(value)
+    }
+}
+
 impl From<FenderValue> for Expression<FenderTypeSystem> {
     fn from(value: FenderValue) -> Self {
         Expression::RawValue(value.into())
@@ -101,12 +113,6 @@ impl From<FenderValue> for Expression<FenderTypeSystem> {
 impl From<FunctionRef<FenderTypeSystem>> for FenderReference {
     fn from(value: FunctionRef<FenderTypeSystem>) -> Self {
         FenderReference::FRaw(FenderValue::Function(value))
-    }
-}
-
-impl Debug for FenderReference {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        (**self).fmt(f)
     }
 }
 
@@ -174,7 +180,7 @@ impl Value for FenderReference {
     }
 }
 
-impl From<FenderReference> for InternalReference {
+impl From<FenderReference> for InternalReference<FenderValue> {
     fn from(value: FenderReference) -> Self {
         match value {
             FenderReference::FRef(val) => val,

--- a/src/fender_reference.rs
+++ b/src/fender_reference.rs
@@ -11,36 +11,36 @@ use std::{
 };
 
 #[derive(Clone, Debug)]
-pub struct InternalReference(Rc<UnsafeCell<FenderValue>>);
+pub struct InternalReference<T>(Rc<UnsafeCell<T>>);
 
-impl InternalReference {
-    pub fn new(value: FenderValue) -> Self {
+impl<T> InternalReference<T> {
+    pub fn new(value: T) -> Self {
         Self(Rc::new(UnsafeCell::new(value)))
     }
 }
 
-impl Deref for InternalReference {
-    type Target = FenderValue;
+impl<T> Deref for InternalReference<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.0.get() }
     }
 }
 
-impl DerefMut for InternalReference {
+impl<T> DerefMut for InternalReference<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { self.0.get().as_mut().unwrap() }
     }
 }
 
-impl PartialEq for InternalReference {
+impl<T: PartialEq> PartialEq for InternalReference<T> {
     fn eq(&self, other: &Self) -> bool {
         **self == **other
     }
 }
 
 pub enum FenderReference {
-    FRef(InternalReference),
+    FRef(InternalReference<FenderValue>),
     FRaw(FenderValue),
 }
 
@@ -174,7 +174,7 @@ impl Value for FenderReference {
     }
 }
 
-impl From<FenderReference> for InternalReference {
+impl From<FenderReference> for InternalReference<FenderValue> {
     fn from(value: FenderReference) -> Self {
         match value {
             FenderReference::FRef(val) => val,

--- a/src/fender_value.rs
+++ b/src/fender_value.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{
     fender_reference::{FenderReference, InternalReference},
     type_sys::{type_id::FenderTypeId, type_system::FenderTypeSystem},
@@ -6,15 +8,15 @@ use freight_vm::{function::FunctionRef, value::Value};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum FenderValue {
-    Ref(InternalReference),
+    Ref(InternalReference<FenderReference>),
     Int(i64),
     Float(f64),
     Char(char),
-    String(String),
+    String(InternalReference<String>),
     Bool(bool),
     Error(String),
     Function(FunctionRef<FenderTypeSystem>),
-    List(Vec<FenderReference>),
+    List(InternalReference<Vec<FenderReference>>),
     #[default]
     Null,
 }
@@ -57,7 +59,7 @@ impl FenderValue {
             Bool(b) => Bool(*b),
             Error(e) => Error(e.clone()),
             Function(f) => Function(f.clone()),
-            List(l) => List(l.iter().map(Value::deep_clone).collect()),
+            List(l) => List(l.iter().map(Value::deep_clone).collect::<Vec<_>>().into()),
             Null => Null,
         }
     }
@@ -106,7 +108,7 @@ impl ToString for FenderValue {
             FenderValue::Int(i) => i.to_string(),
             FenderValue::Float(f) => f.to_string(),
             FenderValue::Char(c) => c.to_string(),
-            FenderValue::String(s) => s.clone(),
+            FenderValue::String(s) => s.deref().clone(),
             FenderValue::Bool(b) => b.to_string(),
             FenderValue::Error(e) => format!("Error({e})"),
             FenderValue::Function(_) => "Function".to_string(),

--- a/src/fender_value.rs
+++ b/src/fender_value.rs
@@ -6,7 +6,7 @@ use freight_vm::{function::FunctionRef, value::Value};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum FenderValue {
-    Ref(InternalReference<FenderValue>),
+    Ref(InternalReference),
     Int(i64),
     Float(f64),
     Char(char),

--- a/src/fender_value.rs
+++ b/src/fender_value.rs
@@ -6,7 +6,7 @@ use freight_vm::{function::FunctionRef, value::Value};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum FenderValue {
-    Ref(InternalReference),
+    Ref(InternalReference<FenderValue>),
     Int(i64),
     Float(f64),
     Char(char),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -507,7 +507,7 @@ fn parse_string(
             "strChar" => str.push(child.source[child.range.start]),
             "escapeSequence" => str.push(parse_escape_seq(child)?),
             "strExpr" => {
-                exprs.push(Expression::from(FenderValue::String(str)));
+                exprs.push(Expression::from(FenderValue::String(str.into())));
                 str = String::new();
                 exprs.push(parse_expr(&child.children[0], writer, scope)?);
             }
@@ -515,9 +515,9 @@ fn parse_string(
         }
     }
     if exprs.is_empty() {
-        return Ok(FenderValue::String(str).into());
+        return Ok(FenderValue::String(str.into()).into());
     }
-    exprs.push(FenderValue::String(str).into());
+    exprs.push(FenderValue::String(str.into()).into());
     Ok(Expression::Initialize(FenderInitializer::String, exprs))
 }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -126,7 +126,7 @@ fn add(a: &FenderReference, b: &FenderReference) -> FenderReference {
     let b_val: &FenderValue = b.into();
     match (a_val, b_val) {
         (FenderValue::String(s), other) | (other, FenderValue::String(s)) => {
-            FenderValue::String(format!("{}{}", s, other.to_string())).into()
+            FenderValue::String(format!("{}{}", s.deref(), other.to_string()).into()).into()
         }
         _ => num_add(a, b),
     }
@@ -223,7 +223,8 @@ impl Initializer<FenderReference> for FenderInitializer {
                 values
                     .into_iter()
                     .map(|val| FenderReference::FRef(InternalReference::from(val)))
-                    .collect(),
+                    .collect::<Vec<_>>()
+                    .into(),
             )
             .into(),
             Self::String => {
@@ -235,7 +236,7 @@ impl Initializer<FenderReference> for FenderInitializer {
                         collected.push_str(&v.to_string());
                     }
                 }
-                FenderValue::String(collected).into()
+                FenderValue::String(collected.into()).into()
             }
         }
     }

--- a/src/stdlib/cast.rs
+++ b/src/stdlib/cast.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{
     fender_value::FenderValue::{self, *},
     fndr_native_func,
@@ -16,7 +18,7 @@ fndr_native_func!(
         Ok(match &*item {
             String(s) => match s.parse() {
                 Ok(i) => Int(i).into(),
-                _ => FenderValue::make_error(format!("Invalid int string: {}", s)).into(),
+                _ => FenderValue::make_error(format!("Invalid int string: {}", s.deref())).into(),
             },
             Int(val) => Int(*val).into(),
             Float(val) => Int(*val as i64).into(),
@@ -34,5 +36,5 @@ fndr_native_func!(
 fndr_native_func!(
     /// Cast `FenderValue` to `FenderValue::String`
     str_func,
-    |_, item| { Ok(String(item.to_string()).into()) }
+    |_, item| { Ok(String(item.to_string().into()).into()) }
 );

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -2,7 +2,7 @@ use crate::{
     fender_value::FenderValue::{self, *},
     fndr_native_func,
 };
-use std::io::Write;
+use std::{io::Write, ops::Deref};
 
 // --- stdout ---
 
@@ -33,7 +33,7 @@ fndr_native_func!(
     read_line_func,
     |_| {
         match std::io::stdin().lines().next() {
-            Some(Ok(s)) => Ok(String(s).into()),
+            Some(Ok(s)) => Ok(String(s.into()).into()),
             Some(Err(e)) => Ok(FenderValue::make_error(e.to_string()).into()),
             None => Ok(FenderValue::make_error("End of file".to_string()).into()),
         }
@@ -49,8 +49,8 @@ fndr_native_func!(
         let String(file_name) = &*file_name else {
         return Ok(FenderValue::make_error("file name must be of type `String`").into());
     };
-        Ok(match std::fs::read_to_string(file_name) {
-            Ok(s) => String(s).into(),
+        Ok(match std::fs::read_to_string(file_name.deref()) {
+            Ok(s) => String(s.into()).into(),
             Err(e) => {
                 FenderValue::make_error(format!("failed to read file due to error: {e}")).into()
             }
@@ -65,7 +65,7 @@ fndr_native_func!(
         let String(file_name) = &*file_name else {
         return Ok(FenderValue::make_error("file name must be of type `String`").into());
     };
-        Ok(match std::fs::write(file_name, data.to_string()) {
+        Ok(match std::fs::write(file_name.deref(), data.to_string()) {
             Ok(s) => Null.into(),
             Err(e) => {
                 FenderValue::make_error(format!("failed to read file due to error: {e}")).into()

--- a/src/stdlib/system.rs
+++ b/src/stdlib/system.rs
@@ -2,7 +2,7 @@ use crate::{
     fender_value::FenderValue::{self, *},
     fndr_native_func,
 };
-use std::process::Command;
+use std::{ops::Deref, process::Command};
 
 fndr_native_func!(
     /// Interact with host system shell
@@ -37,12 +37,13 @@ fndr_native_func!(
         const DEFAULT_SHELL: &str = "sh -c";
 
         let (mut shell, cmd) = match (&*cmd_name, &*shell_path) {
-            (String(name), String(shell)) => {
-                (shell.split(' '), format!("{} {}", name, cmd.to_string()))
-            }
+            (String(name), String(shell)) => (
+                shell.split(' '),
+                format!("{} {}", name.deref(), cmd.to_string()),
+            ),
             (String(name), Null) => (
                 DEFAULT_SHELL.split(' '),
-                format!("{} {}", name, cmd.to_string()),
+                format!("{} {}", name.deref(), cmd.to_string()),
             ),
             (Null, Null) => (DEFAULT_SHELL.split(' '), cmd.to_string()),
             _ => {
@@ -77,7 +78,7 @@ fndr_native_func!(
         };
 
         Ok(if result.status.success() {
-            String(output)
+            String(output.into())
         } else {
             Error(output)
         }

--- a/src/stdlib/val_operation.rs
+++ b/src/stdlib/val_operation.rs
@@ -32,7 +32,7 @@ fndr_native_func!(
         Ok(match variable.deref_mut() {
             List(l) => {
                 l.swap(*pos_a as usize, *pos_b as usize);
-                List(l.to_vec()).into()
+                List(l.to_vec().into()).into()
             }
 
             _ => Error(format!(

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -91,6 +91,11 @@ fn test_pass_by_reference() {
         *run("$a = 4; $f = (n) {n = 0}; f(a); a"),
         FenderValue::Int(4)
     );
+    assert_eq!(
+        *run("$x = []; $f =(n) {n = 4}; f(x); x"),
+        FenderValue::List(vec![])
+    );
+    assert_eq!(*run("{$y = 1; {y = 5}(); y}()"), FenderValue::Int(5));
 }
 
 #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -13,7 +13,7 @@ fn test_simple_values() {
     assert_eq!(*run("1.0"), FenderValue::Float(1.0));
     assert_eq!(
         *run("\"Hello, world!\""),
-        FenderValue::String("Hello, world!".to_string())
+        FenderValue::String("Hello, world!".to_string().into())
     );
     assert_eq!(*run("true"), FenderValue::Bool(true));
     assert_eq!(*run("false"), FenderValue::Bool(false));
@@ -67,20 +67,26 @@ fn test_return() {
 fn test_lists() {
     assert_eq!(
         *run("[1, 2, 3]"),
-        FenderValue::List(vec![
-            FenderValue::Int(1).into(),
-            FenderValue::Int(2).into(),
-            FenderValue::Int(3).into(),
-        ])
+        FenderValue::List(
+            vec![
+                FenderValue::Int(1).into(),
+                FenderValue::Int(2).into(),
+                FenderValue::Int(3).into(),
+            ]
+            .into()
+        )
     );
     assert_eq!(
         *run("$x = 4; [1, 2, 3, x]"),
-        FenderValue::List(vec![
-            FenderValue::Int(1).into(),
-            FenderValue::Int(2).into(),
-            FenderValue::Int(3).into(),
-            FenderValue::Int(4).into(),
-        ])
+        FenderValue::List(
+            vec![
+                FenderValue::Int(1).into(),
+                FenderValue::Int(2).into(),
+                FenderValue::Int(3).into(),
+                FenderValue::Int(4).into(),
+            ]
+            .into()
+        )
     );
     assert_eq!(
         *run("$x = [1, 2, 3]; x[0] = 100; x[0]"),
@@ -97,24 +103,33 @@ fn test_pass_by_reference() {
     );
     assert_eq!(
         *run("$x = []; $f =(n) {n = 4}; f(x); x"),
-        FenderValue::List(vec![])
+        FenderValue::List(vec![].into())
     );
-    assert_eq!(*run("$x = []; $y = x; x = 4; y"), FenderValue::List(vec![]));
+    assert_eq!(
+        *run("$x = []; $y = x; x = 4; y"),
+        FenderValue::List(vec![].into())
+    );
     assert_eq!(*run("{$y = 1; {y = 5}(); y}()"), FenderValue::Int(5));
-    assert_eq!(*run("$x = [1];$f = (n){ n[0] = 2 };f(x);x"), FenderValue::List(vec![FenderValue::Int(2).into()]));
+    assert_eq!(
+        *run("$x = [1];$f = (n){ n[0] = 2 };f(x);x"),
+        FenderValue::List(vec![FenderValue::Int(2).into()].into())
+    );
 }
 
 #[test]
 fn test_format_strings() {
     assert_eq!(
         *run("$x = 4; \"x is equal to {x}\""),
-        FenderValue::String("x is equal to 4".to_string())
+        FenderValue::String("x is equal to 4".to_string().into())
     );
     assert_eq!(
         *run("$x = 4; \"one more than x is {x + 1}\""),
-        FenderValue::String("one more than x is 5".to_string())
+        FenderValue::String("one more than x is 5".to_string().into())
     );
-    assert_eq!(*run("\"\\n\\r\""), FenderValue::String("\n\r".to_string()));
+    assert_eq!(
+        *run("\"\\n\\r\""),
+        FenderValue::String("\n\r".to_string().into())
+    );
 }
 
 #[test]
@@ -122,18 +137,21 @@ fn run_quicksort_test() {
     use FenderValue::Int;
     assert_eq!(
         *run(include_str!("quicksort.fndr")),
-        FenderValue::List(vec![
-            Int(1).into(),
-            Int(2).into(),
-            Int(7).into(),
-            Int(8).into(),
-            Int(9).into(),
-            Int(10).into(),
-            Int(54).into(),
-            Int(57).into(),
-            Int(68).into(),
-            Int(670).into(),
-            Int(1113).into()
-        ])
+        FenderValue::List(
+            vec![
+                Int(1).into(),
+                Int(2).into(),
+                Int(7).into(),
+                Int(8).into(),
+                Int(9).into(),
+                Int(10).into(),
+                Int(54).into(),
+                Int(57).into(),
+                Int(68).into(),
+                Int(670).into(),
+                Int(1113).into()
+            ]
+            .into()
+        )
     );
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -101,6 +101,7 @@ fn test_pass_by_reference() {
     );
     assert_eq!(*run("$x = []; $y = x; x = 4; y"), FenderValue::List(vec![]));
     assert_eq!(*run("{$y = 1; {y = 5}(); y}()"), FenderValue::Int(5));
+    assert_eq!(*run("$x = [1];$f = (n){ n[0] = 2 };f(x);x"), FenderValue::List(vec![FenderValue::Int(2).into()]));
 }
 
 #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -82,6 +82,10 @@ fn test_lists() {
             FenderValue::Int(4).into(),
         ])
     );
+    assert_eq!(
+        *run("$x = [1, 2, 3]; x[0] = 100; x[0]"),
+        FenderValue::Int(100)
+    );
 }
 
 #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -95,6 +95,7 @@ fn test_pass_by_reference() {
         *run("$x = []; $f =(n) {n = 4}; f(x); x"),
         FenderValue::List(vec![])
     );
+    assert_eq!(*run("$x = []; $y = x; x = 4; y"), FenderValue::List(vec![]));
     assert_eq!(*run("{$y = 1; {y = 5}(); y}()"), FenderValue::Int(5));
 }
 


### PR DESCRIPTION
Introduces a new kind of FenderReference, FVar, which allows us to add another layer of indirection for reference types so that the value can be referenced separately from the variable holding it