### PR TITLE
Implement assign-operate

### DIFF
--- a/fender.bnf
+++ b/fender.bnf
@@ -12,7 +12,7 @@ root! ::= break? (statement break)* statement? break?
 statement ::= (import | functionDeclaration | structDeclaration | declaration | assignment | return | expr) sep? comment?
 return ::= "return" ("@" name)? (lineSep expr)?
 declaration ::= "$" sep? name sep? "=" lineSep? expr
-assignOp ::= [-+/*]
+assignOp ::= [-+/*%^]
 assignment ::= expr sep? assignOp? "=" lineSep? expr
 importPath ::= [^: \t\n]+
 import ::= "import" sep ("*" sep?)? importPath (":" name)? (sep importAs)?

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -485,10 +485,14 @@ pub(crate) fn parse_assignment(
         .map(|t| parse_binary_operator(&t.get_match()));
     let target = parse_expr(target, engine, scope)?;
     let value = parse_expr(value, engine, scope)?;
-    if let Some(_op) = op {
-        todo!()
-    }
-    Ok(Expression::AssignDynamic([target, value].into()))
+    Ok(if let Some(op) = op {
+        Expression::BinaryOpEval(
+            FenderBinaryOperator::AssignOperate(op.into()),
+            [target, value].into(),
+        )
+    } else {
+        Expression::AssignDynamic([target, value].into())
+    })
 }
 
 pub(crate) fn parse_return(

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -27,6 +27,7 @@ pub enum FenderBinaryOperator {
     Ne,
     Index,
     FieldAccess,
+    AssignOperate(Box<FenderBinaryOperator>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -246,6 +247,11 @@ impl BinaryOperator<FenderReference> for FenderBinaryOperator {
             Or => num_or(a, b),
             Index => index_op(a, b),
             FieldAccess => field_access(a, b),
+            AssignOperate(op) => {
+                let result = op.apply_2(a, b);
+                a.dupe_ref().assign(result);
+                Default::default()
+            }
         }
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -27,7 +27,7 @@ fn assign_operate() {
     assert_eq!(*run("$x = 4; x += 1; x"), FenderValue::Int(5));
     assert_eq!(*run("$x = 5; x /= 2; x"), FenderValue::Int(2));
     assert_eq!(
-        *run("$abc = \"abc\"; abc += \"def\"; abc"),
+        *run(r#"$abc = "abc"; abc += "def"; abc"#),
         FenderValue::make_string("abcdef".to_string())
     );
     assert_eq!(*run("$x = 10; x %= 3; x"), FenderValue::Int(1));

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -23,6 +23,17 @@ fn test_simple_values() {
 }
 
 #[test]
+fn test_assign_operate() {
+    assert_eq!(*run("$x = 4; x += 1; x"), FenderValue::Int(5));
+    assert_eq!(*run("$x = 5; x /= 2; x"), FenderValue::Int(2));
+    assert_eq!(
+        *run("$abc = \"abc\"; abc += \"def\"; abc"),
+        FenderValue::make_string("abcdef".to_string())
+    );
+    assert_eq!(*run("$x = 10; x %= 3; x"), FenderValue::Int(1));
+}
+
+#[test]
 fn test_algebraic_expressions() {
     assert_eq!(*run("3 + 2"), FenderValue::Int(5));
     assert_eq!(*run("3 + 2 + 2"), FenderValue::Int(7));

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -23,7 +23,7 @@ fn test_simple_values() {
 }
 
 #[test]
-fn test_assign_operate() {
+fn assign_operate() {
     assert_eq!(*run("$x = 4; x += 1; x"), FenderValue::Int(5));
     assert_eq!(*run("$x = 5; x /= 2; x"), FenderValue::Int(2));
     assert_eq!(


### PR DESCRIPTION
Implements combined assignment and operation, like:

```
$x = 1
x += 2
x.println() # Should print 3
```