### PR TITLE
Create type match macro

### DIFF
--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -126,6 +126,25 @@ macro_rules! count {
 }
 
 #[macro_export]
+/// Create a type error for invalid arguments
+macro_rules! type_match {
+    ($($arg:ident),* {
+        $(
+            ($($ty:ident $( ( $($param:ident),* ) )?),*) => $branch:expr
+        ),*
+    }) => {
+        match ($($arg.unwrap_value()),*) {
+            $(( $($ty $( ( $($param),* ) )?),* ) => $branch),* ,
+            _ => return Ok($crate::fender_reference::FenderReference::FRaw(FenderValue::make_error(format!("Invalid argument types {}; expected {}",
+            format!("({})", [$($arg),*].into_iter().map(|a| a.get_real_type_id().to_string()).collect::<Vec<_>>().join(", ")),
+            [
+                    $( format!("({})", [$(stringify!($ty)),*].join(", ")) ),*
+                ].join(" OR "))))),
+        }
+    };
+}
+
+#[macro_export]
 /// Create fender function in rust
 macro_rules! fndr_native_func {
     (

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -126,7 +126,7 @@ macro_rules! count {
 }
 
 #[macro_export]
-/// Create a type error for invalid arguments
+/// Match arguments against their types and generate a nice error message for invalid argument types
 macro_rules! type_match {
     ($($arg:ident),* {
         $(


### PR DESCRIPTION
Type match macro is used like this:
```rs
type_match!(a, b {
  (List(a), List(b)) => Ok(FenderValue::Int(0).into()),
  (Int(a), Int(b)) => Ok(FenderValue::Int(a + b).into())
});
```

It will work like a normal match statement for the listed branches, and also generates a nice informative error message for invalid argument types
![image](https://user-images.githubusercontent.com/14198267/231943561-a560dff3-7361-4315-a7ac-e7822c2e4f33.png)
