### PR TITLE
More portable shebang

### DIFF
--- a/examples/fib.fndr
+++ b/examples/fib.fndr
@@ -1,4 +1,4 @@
-#!/bin/fender
+#!/usr/bin/env fender
 $fib = (n) {
    (n > 1).then {return fib(n - 1) + fib(n - 2)}
    .else {return n}

--- a/examples/simple_blackjack.fndr
+++ b/examples/simple_blackjack.fndr
@@ -1,4 +1,4 @@
-#!/bin/fender
+#!/usr/bin/env fender
 $cardString = (card){
    (card == 1).then({return "A"})
    (card == 11).then({return "J"})

--- a/examples/test.fndr
+++ b/examples/test.fndr
@@ -1,4 +1,4 @@
-#!/bin/fender
+#!/usr/bin/env fender
 
 1.dbg().println()
 1.float().dbg().println()

--- a/src/test/quicksort.fndr
+++ b/src/test/quicksort.fndr
@@ -1,4 +1,4 @@
-#!/bin/fender
+#!/usr/bin/env fender
 
 $quickSort = (array, lower, upper){
    $i = lower


### PR DESCRIPTION
The shebang (the `#!/bin/fender` line) requires fender to be installed in the `/bin` directory. If installed to a different directory, it does not work.

Using `#!/usr/bin/env fender` will use the first `fender` binary found within the `PATH` environment variable - so if it's installed to `/usr/local/bin`, which is the conventional place for binaries installed by the local admin rather than the system, or `/home/eliminmax/.cargo/bin`, which is where `cargo` installs binaries by default on my system, it would still work.

I am a bit of a control freak when it comes to the software on my systems, and I like to keep things organized