### PR TITLE
Enable stack layout optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "freight_vm"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Freight?rev=74e67a12882baf79df47d9acba4acb58ec0cf97b#74e67a12882baf79df47d9acba4acb58ec0cf97b"
+source = "git+https://github.com/FenderLang/Freight?rev=afb65ff6591d3e7a666f1efb0a7e570634a7e19b#afb65ff6591d3e7a666f1efb0a7e570634a7e19b"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "freight_vm"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Freight?rev=a173b44720d215ddd017b854ee5554e9e2c9beae#a173b44720d215ddd017b854ee5554e9e2c9beae"
+source = "git+https://github.com/FenderLang/Freight?rev=21159481ec8df27b643499ace41c5e4a1dbafe65#21159481ec8df27b643499ace41c5e4a1dbafe65"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "freight_vm"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Freight?rev=c2e5d6c7d4714f468e0b37106e1c95e5c0ea7bdd#c2e5d6c7d4714f468e0b37106e1c95e5c0ea7bdd"
+source = "git+https://github.com/FenderLang/Freight?rev=74e67a12882baf79df47d9acba4acb58ec0cf97b#74e67a12882baf79df47d9acba4acb58ec0cf97b"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "freight_vm"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Freight?rev=afb65ff6591d3e7a666f1efb0a7e570634a7e19b#afb65ff6591d3e7a666f1efb0a7e570634a7e19b"
+source = "git+https://github.com/FenderLang/Freight?rev=a173b44720d215ddd017b854ee5554e9e2c9beae#a173b44720d215ddd017b854ee5554e9e2c9beae"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "freight_vm"
 version = "0.1.0"
-source = "git+https://github.com/FenderLang/Freight?rev=21159481ec8df27b643499ace41c5e4a1dbafe65#21159481ec8df27b643499ace41c5e4a1dbafe65"
+source = "git+https://github.com/FenderLang/Freight?rev=55d6b0b747efb4c3a115b5805786101e25a9641f#55d6b0b747efb4c3a115b5805786101e25a9641f"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "a173b44720d215ddd017b854ee5554e9e2c9beae", features = [
+freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "21159481ec8df27b643499ace41c5e4a1dbafe65", features = [
    "variadic_functions",
 ] }
 flux_bnf = { git = "https://github.com/FenderLang/Flux", rev = "0b7b25e36313e76f0aa43d5f61b2f07a99322a72" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "74e67a12882baf79df47d9acba4acb58ec0cf97b", features = [
+freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "afb65ff6591d3e7a666f1efb0a7e570634a7e19b", features = [
    "variadic_functions",
 ] }
 flux_bnf = { git = "https://github.com/FenderLang/Flux", rev = "0b7b25e36313e76f0aa43d5f61b2f07a99322a72" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "afb65ff6591d3e7a666f1efb0a7e570634a7e19b", features = [
+freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "a173b44720d215ddd017b854ee5554e9e2c9beae", features = [
    "variadic_functions",
 ] }
 flux_bnf = { git = "https://github.com/FenderLang/Flux", rev = "0b7b25e36313e76f0aa43d5f61b2f07a99322a72" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "c2e5d6c7d4714f468e0b37106e1c95e5c0ea7bdd", features = [
+freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "74e67a12882baf79df47d9acba4acb58ec0cf97b", features = [
    "variadic_functions",
 ] }
 flux_bnf = { git = "https://github.com/FenderLang/Flux", rev = "0b7b25e36313e76f0aa43d5f61b2f07a99322a72" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "21159481ec8df27b643499ace41c5e4a1dbafe65", features = [
+freight_vm = { git = "https://github.com/FenderLang/Freight", rev = "55d6b0b747efb4c3a115b5805786101e25a9641f", features = [
    "variadic_functions",
 ] }
 flux_bnf = { git = "https://github.com/FenderLang/Flux", rev = "0b7b25e36313e76f0aa43d5f61b2f07a99322a72" }

--- a/src/interpreter/lexical_scope.rs
+++ b/src/interpreter/lexical_scope.rs
@@ -68,7 +68,7 @@ impl<'a> LexicalScope<'a> {
         ) {
             return Err(InterpreterError::DuplicateName(name.to_string(), pos));
         }
-        variables.insert(name, VariableType::Stack(self.num_stack_vars).into());
+        variables.insert(name, VariableType::Stack(self.num_stack_vars));
         self.num_stack_vars += 1;
         Ok(self.num_stack_vars - 1)
     }
@@ -126,9 +126,8 @@ impl<'a> LexicalScope<'a> {
         let mut cur = self;
         let var = loop {
             let variables = cur.variables.borrow();
-            match variables.get(name) {
-                Some(VariableType::Stack(v)) => break *v,
-                _ => {}
+            if let Some(VariableType::Stack(v)) = variables.get(name) {
+                break *v;
             };
             match &cur.parent {
                 Some(parent) => cur = parent,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -147,7 +147,7 @@ pub(crate) fn register_var(
             scope
                 .variables
                 .borrow_mut()
-                .insert(name, VariableType::Global(global));
+                .insert(name, VariableType::Global(global).into());
             let expr = expr(engine, scope)?;
             Expression::AssignGlobal(global, expr.into())
         }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -147,7 +147,7 @@ pub(crate) fn register_var(
             scope
                 .variables
                 .borrow_mut()
-                .insert(name, VariableType::Global(global).into());
+                .insert(name, VariableType::Global(global));
             let expr = expr(engine, scope)?;
             Expression::AssignGlobal(global, expr.into())
         }

--- a/src/interpreter/parsing.rs
+++ b/src/interpreter/parsing.rs
@@ -122,7 +122,7 @@ pub(crate) fn parse_closure(
                 new_scope
                     .variables
                     .borrow_mut()
-                    .insert(arg, VariableType::Stack(index));
+                    .insert(arg, VariableType::Stack(index).into());
             }
             parse_code_body(code_body, engine, &mut new_scope)
         }
@@ -163,6 +163,7 @@ pub(crate) fn parse_code_body(
         function.set_captures(captures);
     }
     new_scope.register_stack_vars(&mut function);
+    function.layout = new_scope.stack_layout.borrow().clone();
     Ok(engine.register_function(function, new_scope.return_target))
 }
 
@@ -289,15 +290,25 @@ pub(crate) fn parse_assignment(
         .children_named("assignOp")
         .next()
         .map(|t| parse_binary_operator(&t.get_match()));
-    let target = parse_expr(target, engine, scope)?;
+    let target_expr = parse_expr(target, engine, scope)?;
+    if let Expression::Variable(_) = target_expr {
+        scope.mark_mutable(
+            &target
+                .rec_iter()
+                .select_token("name")
+                .next()
+                .expect("Left-hand assignment expression did not have a name to mark as mutable")
+                .get_match(),
+        );
+    }
     let value = parse_expr(value, engine, scope)?;
     Ok(if let Some(op) = op {
         Expression::BinaryOpEval(
             FenderBinaryOperator::AssignOperate(op.into()),
-            [target, value].into(),
+            [target_expr, value].into(),
         )
     } else {
-        Expression::AssignDynamic([target, value].into())
+        Expression::AssignDynamic([target_expr, value].into())
     })
 }
 

--- a/src/interpreter/parsing.rs
+++ b/src/interpreter/parsing.rs
@@ -122,7 +122,7 @@ pub(crate) fn parse_closure(
                 new_scope
                     .variables
                     .borrow_mut()
-                    .insert(arg, VariableType::Stack(index).into());
+                    .insert(arg, VariableType::Stack(index));
             }
             parse_code_body(code_body, engine, &mut new_scope)
         }

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -236,7 +236,8 @@ macro_rules! fndr_native_func {
         ) -> Result<$crate::type_sys::fender_reference::FenderReference, freight_vm::error::FreightError> {
             const _ARG_COUNT: usize = $crate::count!($($($arg),*)?);
             $(
-                    let [$($arg),*]: [$crate::type_sys::fender_reference::FenderReference; _ARG_COUNT]  = args.try_into().unwrap();
+                    let [$($arg),*]: [$crate::type_sys::fender_reference::FenderReference; _ARG_COUNT]  = std::array::from_fn(|i| std::mem::take(&mut args[i]));
+
                     )?
             $body
         }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -642,7 +642,7 @@ mod stdlib {
 mod plugin {
     use super::*;
 
-    #[test]
+    // #[test]
     fn list_value() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         nameList
@@ -657,7 +657,7 @@ mod plugin {
         )
     }
 
-    #[test]
+    // #[test]
     fn example_func() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         example2()

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -642,7 +642,7 @@ mod stdlib {
 mod plugin {
     use super::*;
 
-    // #[test]
+    #[test]
     fn list_value() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         nameList
@@ -657,7 +657,7 @@ mod plugin {
         )
     }
 
-    // #[test]
+    #[test]
     fn example_func() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         example2()

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -156,6 +156,14 @@ fn run_pass_by_reference_file() {
 }
 
 #[test]
+fn pass_by_value() {
+    assert_eq!(
+        *run("$a = 0; $list = []; list.push(a); a = 1; list[0]"),
+        FenderValue::Int(0)
+    );
+}
+
+#[test]
 fn format_strings() {
     assert_eq!(
         *run("$x = 4; \"x is equal to {x}\""),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -650,7 +650,7 @@ mod stdlib {
 mod plugin {
     use super::*;
 
-    #[test]
+    // #[test]
     fn list_value() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         nameList
@@ -665,7 +665,7 @@ mod plugin {
         )
     }
 
-    #[test]
+    // #[test]
     fn example_func() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         example2()

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -650,7 +650,7 @@ mod stdlib {
 mod plugin {
     use super::*;
 
-    // #[test]
+    #[test]
     fn list_value() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         nameList
@@ -665,7 +665,7 @@ mod plugin {
         )
     }
 
-    // #[test]
+    #[test]
     fn example_func() {
         let res = run(r#"@plugin src/test/libexample_plugin.so
         example2()

--- a/src/test/passByRef.fndr
+++ b/src/test/passByRef.fndr
@@ -20,9 +20,8 @@ $each = (list, func) {
 
 $map = (list, func) {
     $i = 0
-    list.println()
     while({i < list.len()}, {
-        list[i] = list[i].func()
+        list[i] = func(list[i])
         i = i + 1
     })
     list
@@ -37,4 +36,4 @@ $fold = (list, accum, func) {
     accum
 }
 
-["1", "4", "3"].map(int).list().println().fold(0, (a, b) {a + b})
+["1", "4", "3"].map(int).fold(0, (a, b) {a + b})

--- a/src/test/passByRef.fndr
+++ b/src/test/passByRef.fndr
@@ -20,8 +20,11 @@ $each = (list, func) {
 
 $map = (list, func) {
     $i = 0
+    list.println()
     while({i < list.len()}, {
-        list[i] = func(list[i])
+        list[i].func().type().println()
+        list[i] = list[i].func()
+        list.println()
         i = i + 1
     })
     list

--- a/src/test/passByRef.fndr
+++ b/src/test/passByRef.fndr
@@ -22,9 +22,7 @@ $map = (list, func) {
     $i = 0
     list.println()
     while({i < list.len()}, {
-        list[i].func().type().println()
         list[i] = list[i].func()
-        list.println()
         i = i + 1
     })
     list
@@ -39,4 +37,4 @@ $fold = (list, accum, func) {
     accum
 }
 
-["1", "4", "3"].map(int).fold(0, (a, b) {a + b})
+["1", "4", "3"].map(int).list().println().fold(0, (a, b) {a + b})

--- a/src/type_sys/fender_reference/mod.rs
+++ b/src/type_sys/fender_reference/mod.rs
@@ -134,7 +134,7 @@ impl Value for FenderReference {
 
     fn into_ref(self) -> Self {
         match self {
-            FenderReference::FRef(_) => self,
+            FenderReference::FRef(_) => FenderReference::FRef(self.deref().clone().into()),
             FenderReference::FRaw(v) => FenderReference::FRef(InternalReference::new(v)),
         }
     }

--- a/src/type_sys/fender_reference/mod.rs
+++ b/src/type_sys/fender_reference/mod.rs
@@ -19,7 +19,7 @@ pub enum FenderReference {
 impl FenderReference {
     pub fn get_pass_object(&self) -> FenderReference {
         match self {
-            FenderReference::FRef(r) => FenderReference::FRef(r.deref().clone().into()),
+            FenderReference::FRef(r) => FenderReference::FRaw(r.deref().clone()),
             FenderReference::FRaw(v) => FenderReference::FRaw(v.clone()),
         }
     }

--- a/src/type_sys/fender_reference/mod.rs
+++ b/src/type_sys/fender_reference/mod.rs
@@ -110,7 +110,7 @@ impl Value for FenderReference {
     fn dupe_ref(&self) -> FenderReference {
         match self {
             FenderReference::FRef(internal_ref) => FenderReference::FRef(internal_ref.clone()),
-            FenderReference::FRaw(_) => self.deep_clone(),
+            FenderReference::FRaw(_) => self.clone(),
         }
     }
 


### PR DESCRIPTION
Leads to substantial performance improvements when writing code using immutable values only. Actually was easier to implement than reference pooling, and more impactful at least for this single makeshift benchmark. I think I'll do reference pooling at a later date.