### PR TITLE
Fix REPL validator

### DIFF
--- a/src/interpreter/repl.rs
+++ b/src/interpreter/repl.rs
@@ -4,7 +4,7 @@ use crate::type_sys::{
     freight_type_system::FenderTypeSystem,
 };
 use freight_vm::{execution_engine::ExecutionEngine, function::ArgCount};
-use reedline::{DefaultValidator, Prompt, Reedline, Signal, ValidationResult, Validator};
+use reedline::{Prompt, Reedline, Signal, ValidationResult, Validator};
 use std::error::Error;
 
 pub struct FenderRepl<'a> {


### PR DESCRIPTION
The REPL validator (which determines when hitting enter will start typing a new line of code instead of evaluating it) was using the default option from reedline, which did not take into account escape characters or single quotes within double quotes. I have written a new validator which correctly accounts for these things.